### PR TITLE
feat: Add gen repo list script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 label_gen.sh
 topic_gen.sh
 repos.csv
+.idea/

--- a/gen_repo_list.sh
+++ b/gen_repo_list.sh
@@ -1,0 +1,43 @@
+genRepoList() {
+  # check if gh is installed
+  if ! command -v gh &> /dev/null; then
+    echo "gh command could not be found, please install GitHub CLI."
+    return 1
+  fi
+
+  # Use getopts to parse options
+  # Options include target, owner, append (flag)
+  local TARGET="repo_list.csv"
+  local OWNER=""
+  local APPEND=0
+  while getopts "t:o:a" opt; do
+    case ${opt} in
+      t ) TARGET="$OPTARG" ;;
+      o ) OWNER="$OPTARG" ;;
+      a ) APPEND=1 ;;
+      \? ) echo "Usage: genRepoList -t target_file -o owner [-a]"
+           return 1 ;;
+    esac
+  done
+
+  # Validate required parameters
+  if [[ -z "$OWNER" ]]; then
+    echo "Owner is required. Use -o to specify the owner."
+    echo "Usage: genRepoList -o owner [-t target_file] [-a]"
+    return 1
+  fi
+
+  # ensure target file exists or create it
+  if [[ ! -f "$TARGET" ]]; then
+    touch "$TARGET"
+  fi
+
+  # Create repo csv using gh cli
+  if [[ $APPEND -eq 1 ]]; then
+    gh repo list "${OWNER}" --limit 100 --json owner, name | jq -r '.[] | .owner.login + "," + .name' >> "${TARGET}"
+  else
+    gh repo list "${OWNER}" --limit 100 --json owner, name | jq -r '.[] | .owner.login + "," + .name' > "${TARGET}"
+  fi
+}
+
+genRepoList "$@"

--- a/gen_repo_list.sh
+++ b/gen_repo_list.sh
@@ -1,43 +1,44 @@
-genRepoList() {
-  # check if gh is installed
-  if ! command -v gh &> /dev/null; then
-    echo "gh command could not be found, please install GitHub CLI."
-    return 1
-  fi
+# check if gh is installed
+if ! command -v gh &> /dev/null; then
+  echo "gh command could not be found, please install GitHub CLI."
+  exit 1
+fi
+echo "here0"
+# Use getopts to parse options
+# Options include target, owner, append (flag)
+TARGET="repo_list.csv"
+OWNER=""
+APPEND=0
+while getopts "t:o:a" opt; do
+  case ${opt} in
+    t ) TARGET="${OPTARG}" ;;
+    o ) OWNER="${OPTARG}" ;;
+    a ) APPEND=1 ;;
+    \? ) echo "Usage: genRepoList -t target_file -o owner [-a]"
+         exit 1 ;;
+  esac
+done
 
-  # Use getopts to parse options
-  # Options include target, owner, append (flag)
-  local TARGET="repo_list.csv"
-  local OWNER=""
-  local APPEND=0
-  while getopts "t:o:a" opt; do
-    case ${opt} in
-      t ) TARGET="$OPTARG" ;;
-      o ) OWNER="$OPTARG" ;;
-      a ) APPEND=1 ;;
-      \? ) echo "Usage: genRepoList -t target_file -o owner [-a]"
-           return 1 ;;
-    esac
-  done
+echo "here1"
+# Validate required parameters
+if [[ -z "$OWNER" ]]; then
+  echo "Owner is required. Use -o to specify the owner."
+  echo "Usage: genRepoList -o owner [-t target_file] [-a]"
+  exit 1
+fi
 
-  # Validate required parameters
-  if [[ -z "$OWNER" ]]; then
-    echo "Owner is required. Use -o to specify the owner."
-    echo "Usage: genRepoList -o owner [-t target_file] [-a]"
-    return 1
-  fi
+echo "here2"
+# ensure target file exists or create it
+if [[ ! -f "$TARGET" ]]; then
+  touch "$TARGET"
+fi
 
-  # ensure target file exists or create it
-  if [[ ! -f "$TARGET" ]]; then
-    touch "$TARGET"
-  fi
-
-  # Create repo csv using gh cli
-  if [[ $APPEND -eq 1 ]]; then
-    gh repo list "${OWNER}" --limit 100 --json owner, name | jq -r '.[] | .owner.login + "," + .name' >> "${TARGET}"
-  else
-    gh repo list "${OWNER}" --limit 100 --json owner, name | jq -r '.[] | .owner.login + "," + .name' > "${TARGET}"
-  fi
-}
-
-genRepoList "$@"
+echo "here3"
+# Create repo csv using gh cli
+if [[ $APPEND -eq 1 ]]; then
+  gh repo list "${OWNER}" --json owner,name | jq -r '.[] | .owner.login + "," + .name' >> "${TARGET}"
+  echo "here4"
+else
+  gh repo list "${OWNER}" --json owner,name | jq -r '.[] | .owner.login + "," + .name' > "${TARGET}"
+  echo "here5"
+fi

--- a/gen_repo_list.sh
+++ b/gen_repo_list.sh
@@ -3,7 +3,7 @@ if ! command -v gh &> /dev/null; then
   echo "gh command could not be found, please install GitHub CLI."
   exit 1
 fi
-echo "here0"
+
 # Use getopts to parse options
 # Options include target, owner, append (flag)
 TARGET="repo_list.csv"
@@ -19,7 +19,6 @@ while getopts "t:o:a" opt; do
   esac
 done
 
-echo "here1"
 # Validate required parameters
 if [[ -z "$OWNER" ]]; then
   echo "Owner is required. Use -o to specify the owner."
@@ -27,18 +26,14 @@ if [[ -z "$OWNER" ]]; then
   exit 1
 fi
 
-echo "here2"
 # ensure target file exists or create it
 if [[ ! -f "$TARGET" ]]; then
   touch "$TARGET"
 fi
 
-echo "here3"
 # Create repo csv using gh cli
 if [[ $APPEND -eq 1 ]]; then
   gh repo list "${OWNER}" --json owner,name | jq -r '.[] | .owner.login + "," + .name' >> "${TARGET}"
-  echo "here4"
 else
   gh repo list "${OWNER}" --json owner,name | jq -r '.[] | .owner.login + "," + .name' > "${TARGET}"
-  echo "here5"
 fi


### PR DESCRIPTION
## Description

This pull request adds robust command-line argument parsing and validation to the `gen_repo_list.sh` script, improving its usability and reliability. The script now checks for required dependencies, supports options for specifying the target file, owner, and append mode, and validates required parameters before execution.

Enhancements to script usability and reliability:

* Added a check to ensure the `gh` (GitHub CLI) command is installed before running the script, providing a clear error message if it is missing.
* Implemented command-line option parsing using `getopts`, allowing users to specify the target file (`-t`), owner (`-o`), and append mode (`-a`).
* Added validation to require the `owner` parameter, displaying usage instructions if it is missing.
* Ensured the target file exists or is created before writing output.
* Updated the logic to either append to or overwrite the target CSV file based on the `-a` flag.