### PR TITLE
chore: Add edit mode to gh_label_gen.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 label_gen.sh
+label_edit.sh
 topic_gen.sh
-repos.csv
+*.csv
 .idea/

--- a/gh_label_gen.py
+++ b/gh_label_gen.py
@@ -38,6 +38,41 @@ def gen_topic_script(name:str, repo_list:list[str]):
     
     print("Complete.")
 
+def gen_edit_script(name:str, swap_name:str, description:str, color:str, repo_list:list[str]):
+    from os import chmod
+    print("Generating the Issue Edit shell script")
+
+    command:str = "gh label edit \"" + name + "\" --repo [REPO] "
+    if swap_name != "":
+        command += "--name \"" + swap_name + "\" "
+    if description != "":
+        command += "--description \"" + description + "\" "
+    if color != "":
+        command += "--color \"" + color + "\" "
+
+    cmd_list:list[str] = []
+
+    try:
+        for repo in repo_list:
+            cmd:str = command.replace("[REPO]",repo)
+            cmd_list.append(cmd)
+
+        edit_script:str = "label_edit.sh"
+        with open(edit_script, "w") as script:
+            for line in cmd_list:
+                line += "\n"
+                print(line)
+                script.write(line)
+                script.write("sleep 2\n") # need sleep 2 for gh api to be happy
+
+        print("Generation complete. chmod to 755 to enable execution of the script")
+        chmod(edit_script,0o755)
+
+    except Exception as e:
+        raise e
+
+    print("Complete.")
+
 def gen_label_script(name:str, description:str, color:str, repo_list:list[str], force:bool=False):
     from os import chmod
 
@@ -70,7 +105,7 @@ def gen_label_script(name:str, description:str, color:str, repo_list:list[str], 
 
     print("Complete.")
 
-def parse_audit_args() -> tuple[str,str]:
+def parse_audit_args() -> tuple[str,str,str,str,str,bool,bool,bool]:
     from os.path import exists as path_exists # just need to check if os.path.exists() returns true for the audit file
 
     parser = argparse.ArgumentParser(description="Generate a script that will create several github labels across the repositories in the specified label_list.")
@@ -80,6 +115,8 @@ def parse_audit_args() -> tuple[str,str]:
     parser.add_argument("-c","--color",dest="color",type=str,help="The color code for the label (defined here: https://www.notion.so/swirldslabs/Issue-Management-db25f4d0789044d9addaa196fe10c9aa)")
     parser.add_argument("-t","--topics",dest="topics",action='store_true',help="Tell the script to generate topics instead of labels.")
     parser.add_argument("-f","--force",dest="force",action='store_true',help="Tell the script to force the push of the label if it exists.")
+    parser.add_argument("-e","--edit",dest="edit",action='store_true',help="Tell the script to edit the label if it exists.")
+    parser.add_argument("-s","--swap-name",dest='swap_name',type=str,help="The new name for the label when editing.")
     args = parser.parse_args()
 
     if args.csv_file is None or args.csv_file == "":
@@ -91,12 +128,16 @@ def parse_audit_args() -> tuple[str,str]:
     if args.name is None or args.name == "":
         raise RuntimeError("No label/topic name specified")
     
-    if not args.topics and (args.color is None or args.color == ""):
+    if not args.topics and not args.edit and (args.color is None or args.color == ""):
         raise RuntimeError("Must specify the color for the issue (defined here: https://www.notion.so/swirldslabs/Issue-Management-db25f4d0789044d9addaa196fe10c9aa)")
     
     description:str = ""
     if args.description is not None:
         description = args.description
+
+    swap_name:str = ""
+    if args.swap_name is not None:
+        swap_name = args.swap_name
 
     force:bool = False
     if args.force:
@@ -106,22 +147,31 @@ def parse_audit_args() -> tuple[str,str]:
     if args.topics:
         topics = True
 
-    return args.csv_file, args.name, description, args.color, force, topics
+    edit:bool = False
+    if args.edit:
+        edit = True
+
+    return args.csv_file, args.name, description, swap_name, args.color, force, topics, edit
 
 def main():
     try:
         csv_name:str = ""
         name:str = ""
         description:str = ""
+        swap_name:str = ""
         color:str = ""
         force:bool = False
         topics:bool = False
-        csv_name, name, description, color, force, topics = parse_audit_args()
+        edit:bool = False
+        csv_name, name, description, swap_name, color, force, topics, edit = parse_audit_args()
         repo_list:list[str] = parse_csv(csv=csv_name)
-        if topics == True:
+        if topics:
             gen_topic_script(name=name, repo_list=repo_list)
+        elif edit:
+            color = "" if color is None else color
+            gen_edit_script(name=name, swap_name=swap_name, description=description, color=color, repo_list=repo_list)
         else:
-            gen_label_script(name=name, description=description, color=color, repo_list=repo_list,force=force)
+            gen_label_script(name=name ,description=description, color=color, repo_list=repo_list,force=force)
 
     except Exception as e:
         print(e)


### PR DESCRIPTION
This pull request enhances the `gh_label_gen.py` script by introducing support for editing existing GitHub labels across repositories, in addition to the original label and topic creation functionality. The main changes include a new script generation function for label edits, updates to argument parsing to support edit operations and new label names, and corresponding logic in the main execution flow.

New label editing functionality:

* Added a new function `gen_edit_script` to generate a shell script for editing labels, supporting changes to name, description, and color across multiple repositories. (`[gh_label_gen.pyR41-R75](diffhunk://#diff-15a772c842fa78f5afbf03e1bf728e17d86231cfa7d4b4115954ec22e4e30f35R41-R75)`)
* Updated the main execution logic to call `gen_edit_script` when the new `--edit` flag is provided, allowing users to edit labels instead of just creating them. (`[gh_label_gen.pyL109-R172](diffhunk://#diff-15a772c842fa78f5afbf03e1bf728e17d86231cfa7d4b4115954ec22e4e30f35L109-R172)`)

Argument parsing improvements:

* Extended the `parse_audit_args` function to parse new arguments: `--edit` (to trigger label editing) and `--swap-name` (to specify a new label name), and updated its return signature to include these options. (`[[1]](diffhunk://#diff-15a772c842fa78f5afbf03e1bf728e17d86231cfa7d4b4115954ec22e4e30f35L73-R108)`, `[[2]](diffhunk://#diff-15a772c842fa78f5afbf03e1bf728e17d86231cfa7d4b4115954ec22e4e30f35R118-R119)`)
* Improved validation logic to allow color to be optional when editing labels, and to support the new swap name argument. (`[gh_label_gen.pyL94-R141](diffhunk://#diff-15a772c842fa78f5afbf03e1bf728e17d86231cfa7d4b4115954ec22e4e30f35L94-R141)`)

These changes make the script more flexible by allowing both creation and editing of labels via command-line arguments.